### PR TITLE
Fix/travis python version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ addons:
       - openjdk-8-jdk
 
 install:
+  - ls -la $HOME
+  - export JAVA_HOME=$HOME/openjdk8
   - pip install coveralls
   - pip install pyorient_native
   - ./ci/start-ci.sh $ORIENTDB_VERSION

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,16 +6,20 @@ python:
   - '3.6'
   - '3.8'
 
-#addons:
-#  apt:
-#    sources:
-#      - sourceline: 'ppa:webupd8team/java'
-#    update: true
-#    packages:
-#      - openjdk-8-jdk
+addons:
+  apt:
+    packages:
+      - openjdk-8-jdk
 
 install:
-  - sudo -E apt-get -yq --no-install-suggests --no-install-recommends install openjdk-8-jdk
+  - ls -la /usr
+  - ls -la /usr/lib
+  - ls -la /usr/lib/jvm
+  - ls -la /usr/lib/jvm/java-8-oracle
+  - ls -la /usr/lib/jvm/java-8-oracle/jre
+  - ls -la /usr/lib/jvm/java-8-oracle/jre/bin
+  - ls -la /usr/lib/jvm/java-8-oracle/jre/bin/java
+  - update-alternatives --install /usr/bin/java java /usr/lib/jvm/java-8-oracle/jre/bin/java 1100
   - pip install coveralls
   - pip install pyorient_native
   - ./ci/start-ci.sh $ORIENTDB_VERSION

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ addons:
 
 install:
   - sudo update-alternatives --install /usr/bin/java java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java 1100
+  - export PATH=$JAVA_HOME/bin:/usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
   - pip install coveralls
   - pip install pyorient_native
   - ./ci/start-ci.sh $ORIENTDB_VERSION

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ addons:
       - openjdk-8-jdk
 
 install:
-  - update-alternatives --config java
   - export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
   - pip install coveralls
   - pip install pyorient_native

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
   - '3.5'
   - '3.6'
   - '3.8'
+  - '3.9-dev'
 
 addons:
   apt:
@@ -13,7 +14,6 @@ addons:
 
 install:
   - sudo update-alternatives --install /usr/bin/java java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java 1100
-  - echo $JAVA_HOME
   - export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
   - export PATH=$JAVA_HOME/bin:$PATH
   - pip install coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,9 @@ addons:
 
 install:
   - sudo update-alternatives --install /usr/bin/java java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java 1100
-  - export PATH=$JAVA_HOME/bin:/usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
+  - echo $JAVA_HOME
+  - export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
+  - export PATH=$JAVA_HOME/bin:$PATH
   - pip install coveralls
   - pip install pyorient_native
   - ./ci/start-ci.sh $ORIENTDB_VERSION

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ addons:
 #      - sourceline: 'ppa:webupd8team/java'
 #    update: true
     packages:
-      - openjdk-9-jdk
+      - openjdk-8-jdk
 
 install:
   - pip install coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ addons:
   apt:
 #    sources:
 #      - sourceline: 'ppa:webupd8team/java'
-#    update: true
+    update: true
     packages:
       - openjdk-8-jdk
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ python:
 
 addons:
   apt:
+    sources:
+      - sourceline: 'ppa:webupd8team/java'
+    update: true
     packages:
       - oracle-java9-installer
       - oracle-java9-set-default

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 os: linux
-dist: trusty
+dist: xenial
 language: python
 python:
   - '3.5'
-  - '3.7'
+  - '3.6'
+  - '3.8'
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ addons:
       - openjdk-8-jdk
 
 install:
-  - export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
+  - sudo update-alternatives --install /usr/bin/java java /usr/lib/jvm/java-8-oracle/jre/bin/java 1100
   - pip install coveralls
   - pip install pyorient_native
   - ./ci/start-ci.sh $ORIENTDB_VERSION

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,16 +6,16 @@ python:
   - '3.6'
   - '3.8'
 
-addons:
-  apt:
+#addons:
+#  apt:
 #    sources:
 #      - sourceline: 'ppa:webupd8team/java'
-    update: true
-    packages:
-      - openjdk-8-jdk
+#    update: true
+#    packages:
+#      - openjdk-8-jdk
 
 install:
-  - sudo update-alternatives --install /usr/bin/java java /usr/lib/jvm/java-8-oracle/jre/bin/java 1100
+  - sudo -E apt-get -yq --no-install-suggests --no-install-recommends install openjdk-8-jdk
   - pip install coveralls
   - pip install pyorient_native
   - ./ci/start-ci.sh $ORIENTDB_VERSION

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,11 @@ python:
 addons:
   apt:
     packages:
-      - openjdk-8-jdk
+      - openjdk-9-jdk
 
 install:
-  - sudo update-alternatives --install /usr/bin/java java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java 1100
-  - export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
+  - sudo update-alternatives --install /usr/bin/java java /usr/lib/jvm/java-9-openjdk-amd64/jre/bin/java 1100
+  - export JAVA_HOME=/usr/lib/jvm/java-9-openjdk-amd64
   - export PATH=$JAVA_HOME/bin:$PATH
   - pip install coveralls
   - pip install pyorient_native

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,12 +8,11 @@ python:
 
 addons:
   apt:
-    sources:
-      - sourceline: 'ppa:webupd8team/java'
-    update: true
+#    sources:
+#      - sourceline: 'ppa:webupd8team/java'
+#    update: true
     packages:
-      - oracle-java9-installer
-      - oracle-java9-set-default
+      - openjdk-9-jdk
 
 install:
   - pip install coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,8 @@ addons:
       - openjdk-8-jdk
 
 install:
-  - ls -la $HOME
+  - which java
+  - whereis java
   - export JAVA_HOME=$HOME/openjdk8
   - pip install coveralls
   - pip install pyorient_native

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 os: linux
-dist: xenial
+dist: focal
 language: python
 python:
   - '3.5'
@@ -15,9 +15,8 @@ addons:
       - openjdk-8-jdk
 
 install:
-  - which java
-  - whereis java
-  - export JAVA_HOME=$HOME/openjdk8
+  - update-alternatives --config java
+  - export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
   - pip install coveralls
   - pip install pyorient_native
   - ./ci/start-ci.sh $ORIENTDB_VERSION

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,11 @@ python:
 addons:
   apt:
     packages:
-      - openjdk-9-jdk
+      - openjdk-8-jdk
 
 install:
-  - sudo update-alternatives --install /usr/bin/java java /usr/lib/jvm/java-9-openjdk-amd64/jre/bin/java 1100
-  - export JAVA_HOME=/usr/lib/jvm/java-9-openjdk-amd64
+  - sudo update-alternatives --install /usr/bin/java java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java 1100
+  - export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
   - export PATH=$JAVA_HOME/bin:$PATH
   - pip install coveralls
   - pip install pyorient_native

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ addons:
       - openjdk-8-jdk
 
 install:
-  - update-alternatives --install /usr/bin/java java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java 1100
+  - sudo update-alternatives --install /usr/bin/java java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java 1100
   - pip install coveralls
   - pip install pyorient_native
   - ./ci/start-ci.sh $ORIENTDB_VERSION

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ addons:
 install:
   - sudo update-alternatives --install /usr/bin/java java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java 1100
   - echo $JAVA_HOME
-  - export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
+  - export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
   - export PATH=$JAVA_HOME/bin:$PATH
   - pip install coveralls
   - pip install pyorient_native

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,14 +12,7 @@ addons:
       - openjdk-8-jdk
 
 install:
-  - ls -la /usr
-  - ls -la /usr/lib
-  - ls -la /usr/lib/jvm
-  - ls -la /usr/lib/jvm/java-8-oracle
-  - ls -la /usr/lib/jvm/java-8-oracle/jre
-  - ls -la /usr/lib/jvm/java-8-oracle/jre/bin
-  - ls -la /usr/lib/jvm/java-8-oracle/jre/bin/java
-  - update-alternatives --install /usr/bin/java java /usr/lib/jvm/java-8-oracle/jre/bin/java 1100
+  - update-alternatives --install /usr/bin/java java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java 1100
   - pip install coveralls
   - pip install pyorient_native
   - ./ci/start-ci.sh $ORIENTDB_VERSION


### PR DESCRIPTION
- Upgrade Travis build script to Ubuntu 20.04 Focal due to the missing support of python ≥ 3.7 in Ubuntu Trusty
- Add more flexibility for the used Java version